### PR TITLE
Release 0.11.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Valheim.SpawnThat/Thunderstore/*/*
 Thunderstore/*/*
 Valheim.SpawnThat/packages
 .vs
+packages

--- a/Thunderstore/README.md
+++ b/Thunderstore/README.md
@@ -57,6 +57,8 @@ ConditionNearbyPlayerCarryLegendaryItem = HeimdallLegs
 ```
 
 # Changelog: 
+- v0.11.5:
+	- More v0.205.5 fixes. World spawners were changed from no longer being per zone, but properly global, meaning Spawn That was reapplying its changes more than once.
 - v0.11.4:
 	- Fixes for Valheim v0.205.5
 - v0.11.3:

--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spawn_That",
-  "version_number": "0.11.4",
+  "version_number": "0.11.5",
   "website_url": "https://github.com/ASharpPen/Valheim.SpawnThat",
   "description": "Advanced tool for customizing mob spawners throughout the world with configuration files.",
   "dependencies": [

--- a/Valheim.SpawnThat/Properties/AssemblyInfo.cs
+++ b/Valheim.SpawnThat/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.4.0")]
-[assembly: AssemblyFileVersion("0.11.4.0")]
+[assembly: AssemblyVersion("0.11.5.0")]
+[assembly: AssemblyFileVersion("0.11.5.0")]

--- a/Valheim.SpawnThat/SpawnThatPlugin.cs
+++ b/Valheim.SpawnThat/SpawnThatPlugin.cs
@@ -8,7 +8,7 @@ namespace Valheim.SpawnThat
     [BepInDependency("RagnarsRokare.MobAILib", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("org.bepinex.plugins.creaturelevelcontrol", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("randyknapp.mods.epicloot", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("asharppen.valheim.spawn_that", "Spawn That!", "0.11.4")]
+    [BepInPlugin("asharppen.valheim.spawn_that", "Spawn That!", "0.11.5")]
     public class SpawnThatPlugin : BaseUnityPlugin
     {        
         // Awake is called once when both the game and the plug-in are loaded

--- a/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Conditions/ConditionDistanceToCenter.cs
+++ b/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Conditions/ConditionDistanceToCenter.cs
@@ -1,29 +1,28 @@
-﻿
-using UnityEngine;
+﻿using UnityEngine;
 using Valheim.SpawnThat.Configuration.ConfigTypes;
 using Valheim.SpawnThat.Core;
 
 namespace Valheim.SpawnThat.Spawners.SpawnerSpawnSystem.Conditions
 {
-    internal class ConditionDistanceToCenter : IConditionOnAwake
+    internal class ConditionDistanceToCenter : IConditionOnSpawn
     {
         private static ConditionDistanceToCenter _instance;
 
         public static ConditionDistanceToCenter Instance => _instance ??= new();
 
-        public bool ShouldFilter(SpawnSystem spawner, SpawnConfiguration spawnConfig)
+        public bool ShouldFilter(SpawnConditionContext context)
         {
-            if(!spawner || spawner is null || spawnConfig is null)
+            if (context is null || context.Config is null)
             {
                 return false;
             }
 
-            if(IsValid(spawner.transform.position, spawnConfig))
+            if (IsValid(context.Position, context.Config))
             {
                 return false;
             }
 
-            Log.LogTrace($"Filtering {spawnConfig.Name} due to distance to center.");
+            Log.LogTrace($"Filtering {context.Config.Name} due to distance to center.");
             return true;
         }
 

--- a/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Conditions/ConditionLocation.cs
+++ b/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Conditions/ConditionLocation.cs
@@ -7,25 +7,25 @@ using Valheim.SpawnThat.Utilities;
 
 namespace Valheim.SpawnThat.Spawners.SpawnerSpawnSystem.Conditions
 {
-    public class ConditionLocation : IConditionOnAwake
+    public class ConditionLocation : IConditionOnSpawn
     {
         private static ConditionLocation _instance;
 
         public static ConditionLocation Instance => _instance ??= new();
-
-        public bool ShouldFilter(SpawnSystem spawner, SpawnConfiguration config)
+        
+        public bool ShouldFilter(SpawnConditionContext context)
         {
-            if (!spawner || spawner is null || config is null)
+            if (context is null || context.Config is null)
             {
                 return false;
             }
 
-            if (IsValid(spawner.transform.position, config))
+            if (IsValid(context.Position, context.Config))
             {
                 return false;
             }
 
-            Log.LogTrace($"Ignoring world config {config.Name} due to spawner not being in required location.");
+            Log.LogTrace($"Ignoring world config {context.Config.Name} due to spawner not being in required location.");
             return true;
         }
 

--- a/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Debug/Patch_SpawnSystem_InjectLogs.cs
+++ b/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Debug/Patch_SpawnSystem_InjectLogs.cs
@@ -1,4 +1,4 @@
-﻿#if TRUE && DEBUG
+﻿#if FALSE && DEBUG
 
 using HarmonyLib;
 using System;

--- a/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Managers/SpawnConditionManager.cs
+++ b/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Managers/SpawnConditionManager.cs
@@ -27,13 +27,9 @@ namespace Valheim.SpawnThat.Spawners.SpawnerSpawnSystem.Managers
                 _instance = null;
             });
 
-            // OnAwake conditions
-
-            OnAwakeConditions.Add(ConditionDistanceToCenter.Instance);
-            OnAwakeConditions.Add(ConditionLocation.Instance);
-
             // OnSpawn conditions
-
+            OnSpawnConditions.Add(ConditionDistanceToCenter.Instance);
+            OnSpawnConditions.Add(ConditionLocation.Instance);
             OnSpawnConditions.Add(ConditionWorldAge.Instance);
             OnSpawnConditions.Add(ConditionNotGlobalKeys.Instance);
             OnSpawnConditions.Add(ConditionNearbyPlayersCarryValue.Instance);

--- a/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Managers/SpawnSystemConfigManager.cs
+++ b/Valheim.SpawnThat/Spawners/SpawnerSpawnSystem/Managers/SpawnSystemConfigManager.cs
@@ -62,6 +62,12 @@ namespace Valheim.SpawnThat.Spawners.SpawnerSpawnSystem.Managers
 
         public static void ApplyConfigs(SpawnSystem __instance, Heightmap ___m_heightmap)
         {
+            if (!FirstApplication)
+            {
+                __instance.SetSuccessfulInit();
+                return;
+            }
+
             if (__instance.transform?.position is null)
             {
                 __instance.SetSuccessfulInit();
@@ -153,7 +159,7 @@ namespace Valheim.SpawnThat.Spawners.SpawnerSpawnSystem.Managers
             {
                 foreach (var spawner in spawners)
                 {
-                    if (string.IsNullOrWhiteSpace(spawner.m_prefab?.name))
+                    if (spawner is null || !spawner.m_prefab || string.IsNullOrWhiteSpace(spawner.m_prefab?.name))
                     {
                         continue;
                     }


### PR DESCRIPTION
- More v0.205.5 fixes. World spawners were changed from no longer being per zone, but properly global, meaning Spawn That was reapplying its changes more than once.