### PR TITLE
Release v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ If you feel like it
 <a href="https://www.buymeacoffee.com/asharppen"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=asharppen&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
 
 # Changelog: 
+- v1.0.3:
+	- Fixed local spawner file-configs not being properly matched with spawners.
+	- Fixed error when printing world spawners with missing prefab to debug file.
+	- Fixed error when having file-configurations with integrations not installed.
+	- Added robustness to API when setting up configurations for uninstalled integrations.
+	- Added robustness for v0.207.15
 - v1.0.2:
 	- Fixed error spawn from world spawners, when joining a server with no world spawner configurations.
 - v1.0.1:

--- a/Thunderstore/manifest.json
+++ b/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spawn_That",
-  "version_number": "1.0.2",
+  "version_number": "1.0.3",
   "website_url": "https://github.com/ASharpPen/Valheim.SpawnThat",
   "description": "Advanced tool for customizing mob spawners throughout the world with configuration files.",
   "dependencies": [

--- a/src/SpawnThat.Docs/articles/change-log.md
+++ b/src/SpawnThat.Docs/articles/change-log.md
@@ -1,5 +1,12 @@
 # Change Log
-
+- v1.0.3:
+	- Fixed local spawner file-configs not being properly matched with spawners.
+	- Fixed error when printing world spawners with missing prefab to debug file.
+	- Fixed error when having file-configurations with integrations not installed.
+	- Added robustness to API when setting up configurations for uninstalled integrations.
+	- Added robustness for v0.207.15
+- v1.0.2:
+	- Fixed error spawn from world spawners, when joining a server with no world spawner configurations.
 - v1.0.1:
 	- Fixed broken config sync.
 - v1.0.0:

--- a/src/SpawnThat/Debugging/SpawnDataFileDumper.cs
+++ b/src/SpawnThat/Debugging/SpawnDataFileDumper.cs
@@ -78,11 +78,11 @@ internal static class SpawnDataFileDumper
 
         try
         {
-            lines.Add($"{nameof(SpawnConfiguration.PrefabName)}={spawner.m_prefab.name}");
+            lines.Add($"{nameof(SpawnConfiguration.PrefabName)}={spawner.m_prefab.GetCleanedName()}");
         }
         catch (Exception e)
         {
-            Log.LogWarning($"Error while attempting to read name of prefab for spawner {spawner}", e);
+            Log.LogWarning($"Error while attempting to read name of prefab for world spawn {spawner?.m_name}, to print to debug file.", e);
         }
 
         lines.Add($"{nameof(SpawnConfiguration.HuntPlayer)}={spawner.m_huntPlayer}");

--- a/src/SpawnThat/Integrations/CLLC/Extensions/CllcBossAffixExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/CllcBossAffixExtensions.cs
@@ -1,0 +1,22 @@
+﻿using CreatureLevelControl;
+using SpawnThat.Integrations.CLLC.Models;
+
+namespace SpawnThat.Integrations.CLLC;
+
+internal static class CllcBossAffixExtensions
+{
+    public static BossAffix Convert(this CllcBossAffix affix)
+    {
+        return affix switch
+        {
+            CllcBossAffix.Reflective => BossAffix.Reflective,
+            CllcBossAffix.Shielded => BossAffix.Shielded,
+            CllcBossAffix.Mending => BossAffix.Mending,
+            CllcBossAffix.Summoner => BossAffix.Summoner,
+            CllcBossAffix.Elementalist => BossAffix.Elementalist,
+            CllcBossAffix.Enraged => BossAffix.Enraged,
+            CllcBossAffix.Twin => BossAffix.Twin,
+            _ => BossAffix.None,
+        };
+    }
+}

--- a/src/SpawnThat/Integrations/CLLC/Extensions/CllcCreatureExtraEffectExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/CllcCreatureExtraEffectExtensions.cs
@@ -1,0 +1,21 @@
+﻿using CreatureLevelControl;
+using SpawnThat.Integrations.CLLC.Models;
+
+namespace SpawnThat.Integrations.CLLC;
+
+internal static class CllcCreatureExtraEffectExtensions
+{
+    public static CreatureExtraEffect Convert(this CllcCreatureExtraEffect extraEffect)
+    {
+        return extraEffect switch
+        {
+            CllcCreatureExtraEffect.Aggressive => CreatureExtraEffect.Aggressive,
+            CllcCreatureExtraEffect.Quick => CreatureExtraEffect.Quick,
+            CllcCreatureExtraEffect.Regenerating => CreatureExtraEffect.Regenerating,
+            CllcCreatureExtraEffect.Curious => CreatureExtraEffect.Curious,
+            CllcCreatureExtraEffect.Splitting => CreatureExtraEffect.Splitting,
+            CllcCreatureExtraEffect.Armored => CreatureExtraEffect.Armored,
+            _ => CreatureExtraEffect.None,
+        };
+    }
+}

--- a/src/SpawnThat/Integrations/CLLC/Extensions/CllcCreatureInfusionExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/CllcCreatureInfusionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using CreatureLevelControl;
+using SpawnThat.Integrations.CLLC.Models;
+
+namespace SpawnThat.Integrations.CLLC;
+
+internal static class CllcCreatureInfusionExtensions
+{
+    public static CreatureInfusion Convert(this CllcCreatureInfusion infusion)
+    {
+        return infusion switch
+        {
+            CllcCreatureInfusion.Lightning => CreatureInfusion.Lightning,
+            CllcCreatureInfusion.Fire => CreatureInfusion.Fire,
+            CllcCreatureInfusion.Frost => CreatureInfusion.Frost,
+            CllcCreatureInfusion.Poison => CreatureInfusion.Poison,
+            CllcCreatureInfusion.Chaos => CreatureInfusion.Chaos,
+            CllcCreatureInfusion.Spirit => CreatureInfusion.Spirit,
+            _ => CreatureInfusion.None,
+        };
+    }
+}

--- a/src/SpawnThat/Integrations/CLLC/Extensions/ILocalSpawnBuilderCllcConditionExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/ILocalSpawnBuilderCllcConditionExtensions.cs
@@ -9,9 +9,11 @@ public static class ILocalSpawnBuilderCllcConditionExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetCondition(new ConditionWorldLevel(minWorldLevel, maxWorldLevel));
+            SetConditionWorldLevel(builder, minWorldLevel, maxWorldLevel);
         }
 
         return builder;
     }
+
+    private static void SetConditionWorldLevel(ILocalSpawnBuilder builder, int? minWorldLevel, int? maxWorldLevel) => builder.SetCondition(new ConditionWorldLevel(minWorldLevel, maxWorldLevel));
 }

--- a/src/SpawnThat/Integrations/CLLC/Extensions/ILocalSpawnBuilderCllcModifierExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/ILocalSpawnBuilderCllcModifierExtensions.cs
@@ -10,7 +10,7 @@ public static class ILocalSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcBossAffix(bossAffixName));
+            SetBossAffix(builder, bossAffixName);
         }
 
         return builder;
@@ -20,17 +20,20 @@ public static class ILocalSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcBossAffix(bossAffix));
+            SetBossAffix(builder, bossAffix);
         }
 
         return builder;
     }
 
+    private static void SetBossAffix(ILocalSpawnBuilder builder, string bossAffixName) => builder.SetModifier(new ModifierCllcBossAffix(bossAffixName));
+    private static void SetBossAffix(ILocalSpawnBuilder builder, CllcBossAffix bossAffix) => builder.SetModifier(new ModifierCllcBossAffix(bossAffix));
+
     public static ILocalSpawnBuilder SetCllcModifierExtraEffect(this ILocalSpawnBuilder builder, string extraEffectName)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcExtraEffect(extraEffectName));
+            SetExtraEffect(builder, extraEffectName);
         }
 
         return builder;
@@ -40,17 +43,20 @@ public static class ILocalSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcExtraEffect(extraEffect));
+            SetExtraEffect(builder, extraEffect);
         }
 
         return builder;
     }
 
+    private static void SetExtraEffect(ILocalSpawnBuilder builder, string extraEffectName) => builder.SetModifier(new ModifierCllcExtraEffect(extraEffectName));
+    private static void SetExtraEffect(ILocalSpawnBuilder builder, CllcCreatureExtraEffect extraEffect) => builder.SetModifier(new ModifierCllcExtraEffect(extraEffect));
+
     public static ILocalSpawnBuilder SetCllcModifierInfusion(this ILocalSpawnBuilder builder, string infusionName)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcInfusion(infusionName));
+            SetInfusion(builder, infusionName);
         }
 
         return builder;
@@ -60,19 +66,25 @@ public static class ILocalSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcInfusion(infusion));
+            SetInfusion(builder, infusion);
         }
 
         return builder;
     }
+
+    private static void SetInfusion(ILocalSpawnBuilder builder, string infusionName) => builder.SetModifier(new ModifierCllcInfusion(infusionName));
+    private static void SetInfusion(ILocalSpawnBuilder builder, CllcCreatureInfusion infusion) => builder.SetModifier(new ModifierCllcInfusion(infusion));
+
 
     public static ILocalSpawnBuilder SetCllcModifierRandomLevel(this ILocalSpawnBuilder builder)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcRandomLevel());
+            SetRandomLevel(builder);
         }
 
         return builder;
     }
+
+    private static void SetRandomLevel(ILocalSpawnBuilder builder) => builder.SetModifier(new ModifierCllcRandomLevel());
 }

--- a/src/SpawnThat/Integrations/CLLC/Extensions/IWorldSpawnBuilderCllcConditionExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/IWorldSpawnBuilderCllcConditionExtensions.cs
@@ -9,9 +9,11 @@ public static class IWorldSpawnBuilderCllcConditionExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetCondition(new ConditionWorldLevel(minWorldLevel, maxWorldLevel));
+            SetConditionWorldLevel(builder, minWorldLevel, maxWorldLevel);
         }
 
         return builder;
     }
+
+    private static void SetConditionWorldLevel(IWorldSpawnBuilder builder, int? minWorldLevel, int? maxWorldLevel) => builder.SetCondition(new ConditionWorldLevel(minWorldLevel, maxWorldLevel));
 }

--- a/src/SpawnThat/Integrations/CLLC/Extensions/IWorldSpawnBuilderCllcModifierExtensions.cs
+++ b/src/SpawnThat/Integrations/CLLC/Extensions/IWorldSpawnBuilderCllcModifierExtensions.cs
@@ -10,7 +10,7 @@ public static class IWorldSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcBossAffix(bossAffixName));
+            SetBossAffix(builder, bossAffixName);
         }
 
         return builder;
@@ -20,39 +20,53 @@ public static class IWorldSpawnBuilderCllcModifierExtensions
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcBossAffix(bossAffix));
+            SetBossAffix(builder, bossAffix);
         }
 
         return builder;
     }
+
+    private static void SetBossAffix(IWorldSpawnBuilder builder, string bossAffixName) => builder.SetModifier(new ModifierCllcBossAffix(bossAffixName));
+    private static void SetBossAffix(IWorldSpawnBuilder builder, CllcBossAffix bossAffix) => builder.SetModifier(new ModifierCllcBossAffix(bossAffix));
+
 
     public static IWorldSpawnBuilder SetCllcModifierExtraEffect(this IWorldSpawnBuilder builder, CllcCreatureExtraEffect extraEffect)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcExtraEffect(extraEffect));
+            SetExtraEffect(builder, extraEffect);
         }
 
         return builder;
     }
+
+
+    private static void SetExtraEffect(IWorldSpawnBuilder builder, string extraEffectName) => builder.SetModifier(new ModifierCllcExtraEffect(extraEffectName));
+    private static void SetExtraEffect(IWorldSpawnBuilder builder, CllcCreatureExtraEffect extraEffect) => builder.SetModifier(new ModifierCllcExtraEffect(extraEffect));
+
 
     public static IWorldSpawnBuilder SetCllcModifierInfusion(this IWorldSpawnBuilder builder, CllcCreatureInfusion infusion)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcInfusion(infusion));
+            SetInfusion(builder, infusion);
         }
 
         return builder;
     }
+
+    private static void SetInfusion(IWorldSpawnBuilder builder, string infusionName) => builder.SetModifier(new ModifierCllcInfusion(infusionName));
+    private static void SetInfusion(IWorldSpawnBuilder builder, CllcCreatureInfusion infusion) => builder.SetModifier(new ModifierCllcInfusion(infusion));
 
     public static IWorldSpawnBuilder SetCllcModifierRandomLevel(this IWorldSpawnBuilder builder)
     {
         if (IntegrationManager.InstalledCLLC)
         {
-            builder.SetModifier(new ModifierCllcRandomLevel());
+            SetRandomLevel(builder);
         }
 
         return builder;
     }
+
+    private static void SetRandomLevel(IWorldSpawnBuilder builder) => builder.SetModifier(new ModifierCllcRandomLevel());
 }

--- a/src/SpawnThat/Integrations/CLLC/Models/CllcBossAffix.cs
+++ b/src/SpawnThat/Integrations/CLLC/Models/CllcBossAffix.cs
@@ -1,6 +1,4 @@
-﻿using CreatureLevelControl;
-
-namespace SpawnThat.Integrations.CLLC.Models;
+﻿namespace SpawnThat.Integrations.CLLC.Models;
 
 public enum CllcBossAffix
 {
@@ -12,22 +10,4 @@ public enum CllcBossAffix
     Elementalist,
     Enraged,
     Twin
-}
-
-internal static class CllcBossAffixExtensions
-{
-    public static BossAffix Convert(this CllcBossAffix affix)
-    {
-        return affix switch
-        {
-            CllcBossAffix.Reflective => BossAffix.Reflective,
-            CllcBossAffix.Shielded => BossAffix.Shielded,
-            CllcBossAffix.Mending => BossAffix.Mending,
-            CllcBossAffix.Summoner => BossAffix.Summoner,
-            CllcBossAffix.Elementalist => BossAffix.Elementalist,
-            CllcBossAffix.Enraged => BossAffix.Enraged,
-            CllcBossAffix.Twin => BossAffix.Twin,
-            _ => BossAffix.None,
-        };
-    }
 }

--- a/src/SpawnThat/Integrations/CLLC/Models/CllcCreatureExtraEffect.cs
+++ b/src/SpawnThat/Integrations/CLLC/Models/CllcCreatureExtraEffect.cs
@@ -1,6 +1,4 @@
-﻿using CreatureLevelControl;
-
-namespace SpawnThat.Integrations.CLLC.Models;
+﻿namespace SpawnThat.Integrations.CLLC.Models;
 
 public enum CllcCreatureExtraEffect
 {
@@ -11,21 +9,4 @@ public enum CllcCreatureExtraEffect
     Curious,
     Splitting,
     Armored
-}
-
-internal static class CllcCreatureExtraEffectExtensions
-{
-    public static CreatureExtraEffect Convert(this CllcCreatureExtraEffect extraEffect)
-    {
-        return extraEffect switch
-        {
-            CllcCreatureExtraEffect.Aggressive => CreatureExtraEffect.Aggressive,
-            CllcCreatureExtraEffect.Quick => CreatureExtraEffect.Quick,
-            CllcCreatureExtraEffect.Regenerating => CreatureExtraEffect.Regenerating,
-            CllcCreatureExtraEffect.Curious => CreatureExtraEffect.Curious,
-            CllcCreatureExtraEffect.Splitting => CreatureExtraEffect.Splitting,
-            CllcCreatureExtraEffect.Armored => CreatureExtraEffect.Armored,
-            _ => CreatureExtraEffect.None,
-        };
-    }
 }

--- a/src/SpawnThat/Integrations/CLLC/Models/CllcCreatureInfusion.cs
+++ b/src/SpawnThat/Integrations/CLLC/Models/CllcCreatureInfusion.cs
@@ -1,6 +1,4 @@
-﻿using CreatureLevelControl;
-
-namespace SpawnThat.Integrations.CLLC.Models;
+﻿namespace SpawnThat.Integrations.CLLC.Models;
 
 public enum CllcCreatureInfusion
 {
@@ -11,21 +9,4 @@ public enum CllcCreatureInfusion
     Poison,
     Chaos,
     Spirit
-}
-
-internal static class CllcCreatureInfusionExtensions
-{
-    public static CreatureInfusion Convert(this CllcCreatureInfusion infusion)
-    {
-        return infusion switch
-        {
-            CllcCreatureInfusion.Lightning => CreatureInfusion.Lightning,
-            CllcCreatureInfusion.Fire => CreatureInfusion.Fire,
-            CllcCreatureInfusion.Frost => CreatureInfusion.Frost,
-            CllcCreatureInfusion.Poison => CreatureInfusion.Poison,
-            CllcCreatureInfusion.Chaos => CreatureInfusion.Chaos,
-            CllcCreatureInfusion.Spirit => CreatureInfusion.Spirit,
-            _ => CreatureInfusion.None,
-        };
-    }
 }

--- a/src/SpawnThat/Integrations/EpicLoot/Extensions/EpicLootRarityExtensions.cs
+++ b/src/SpawnThat/Integrations/EpicLoot/Extensions/EpicLootRarityExtensions.cs
@@ -1,0 +1,25 @@
+﻿using EpicLoot;
+using SpawnThat.Integrations.EpicLoot.Models;
+
+namespace SpawnThat.Integrations.EpicLoot;
+
+internal static class EpicLootRarityExtensions
+{
+    public static ItemRarity ToRarity(this EpicLootRarity rarity)
+        => rarity switch
+        {
+            EpicLootRarity.Magic => ItemRarity.Magic,
+            EpicLootRarity.Rare => ItemRarity.Rare,
+            EpicLootRarity.Epic => ItemRarity.Epic,
+            EpicLootRarity.Legendary => ItemRarity.Legendary,
+        };
+
+    public static EpicLootRarity ToRarity(this ItemRarity rarity)
+        => rarity switch
+        {
+            ItemRarity.Magic => EpicLootRarity.Magic,
+            ItemRarity.Rare => EpicLootRarity.Rare,
+            ItemRarity.Epic => EpicLootRarity.Epic,
+            ItemRarity.Legendary => EpicLootRarity.Legendary,
+        };
+}

--- a/src/SpawnThat/Integrations/EpicLoot/Extensions/ILocalSpawnBuilderELConditionsExtensions.cs
+++ b/src/SpawnThat/Integrations/EpicLoot/Extensions/ILocalSpawnBuilderELConditionsExtensions.cs
@@ -11,7 +11,7 @@ public static class ILocalSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -21,7 +21,7 @@ public static class ILocalSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -31,7 +31,7 @@ public static class ILocalSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -41,17 +41,23 @@ public static class ILocalSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
     }
 
+    private static void SetConditionItemRarity(ILocalSpawnBuilder builder, int distance, IEnumerable<string> rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(ILocalSpawnBuilder builder, int distance, params string[] rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(ILocalSpawnBuilder builder, int distance, IEnumerable<EpicLootRarity> rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(ILocalSpawnBuilder builder, int distance, params EpicLootRarity[] rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+
+
     public static ILocalSpawnBuilder SetEpicLootConditionNearbyPlayerCarryLegendaryItem(this ILocalSpawnBuilder builder, int distanceToSearch, IEnumerable<string> legendaryItemIds)
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+            SetConditionLegendaryItem(builder, distanceToSearch, legendaryItemIds);
         }
 
         return builder;
@@ -61,9 +67,12 @@ public static class ILocalSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+            SetConditionLegendaryItem(builder, distanceToSearch, legendaryItemIds);
         }
 
         return builder;
     }
+
+    private static void SetConditionLegendaryItem(ILocalSpawnBuilder builder, int distanceToSearch, IEnumerable<string> legendaryItemIds) => builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+    private static void SetConditionLegendaryItem(ILocalSpawnBuilder builder, int distanceToSearch, params string[] legendaryItemIds) => builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
 }

--- a/src/SpawnThat/Integrations/EpicLoot/Extensions/IWorldSpawnBuilderELConditionsExtensions.cs
+++ b/src/SpawnThat/Integrations/EpicLoot/Extensions/IWorldSpawnBuilderELConditionsExtensions.cs
@@ -2,6 +2,7 @@
 using SpawnThat.Integrations;
 using SpawnThat.Integrations.EpicLoot.Conditions;
 using SpawnThat.Integrations.EpicLoot.Models;
+using SpawnThat.Spawners.LocalSpawner;
 
 namespace SpawnThat.Spawners.WorldSpawner;
 
@@ -11,7 +12,7 @@ public static class IWorldSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -21,7 +22,7 @@ public static class IWorldSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -31,7 +32,7 @@ public static class IWorldSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
@@ -41,18 +42,22 @@ public static class IWorldSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distanceToSearch, rarities));
+            SetConditionItemRarity(builder, distanceToSearch, rarities);
         }
 
         return builder;
     }
 
+    private static void SetConditionItemRarity(IWorldSpawnBuilder builder, int distance, IEnumerable<string> rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(IWorldSpawnBuilder builder, int distance, params string[] rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(IWorldSpawnBuilder builder, int distance, IEnumerable<EpicLootRarity> rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
+    private static void SetConditionItemRarity(IWorldSpawnBuilder builder, int distance, params EpicLootRarity[] rarities) => builder.SetCondition(new ConditionNearbyPlayerCarryItemWithRarity(distance, rarities));
 
     public static IWorldSpawnBuilder SetEpicLootConditionNearbyPlayerCarryLegendaryItem(this IWorldSpawnBuilder builder, int distanceToSearch, IEnumerable<string> legendaryItemIds)
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+            SetConditionLegendaryItem(builder, distanceToSearch, legendaryItemIds);
         }
 
         return builder;
@@ -62,9 +67,12 @@ public static class IWorldSpawnBuilderELConditionsExtensions
     {
         if (IntegrationManager.InstalledEpicLoot)
         {
-            builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+            SetConditionLegendaryItem(builder, distanceToSearch, legendaryItemIds);
         }
 
         return builder;
     }
+
+    private static void SetConditionLegendaryItem(IWorldSpawnBuilder builder, int distanceToSearch, IEnumerable<string> legendaryItemIds) => builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
+    private static void SetConditionLegendaryItem(IWorldSpawnBuilder builder, int distanceToSearch, params string[] legendaryItemIds) => builder.SetCondition(new ConditionNearbyPlayerCarryLegendaryItem(distanceToSearch, legendaryItemIds));
 }

--- a/src/SpawnThat/Integrations/EpicLoot/Models/EpicLootRarity.cs
+++ b/src/SpawnThat/Integrations/EpicLoot/Models/EpicLootRarity.cs
@@ -1,6 +1,4 @@
-﻿using EpicLoot;
-
-namespace SpawnThat.Integrations.EpicLoot.Models;
+﻿namespace SpawnThat.Integrations.EpicLoot.Models;
 
 public enum EpicLootRarity
 {
@@ -8,25 +6,4 @@ public enum EpicLootRarity
     Rare,
     Epic,
     Legendary,
-}
-
-internal static class EpicLootRarityExtensions
-{
-    public static ItemRarity ToRarity(this EpicLootRarity rarity)
-        => rarity switch
-        {
-            EpicLootRarity.Magic => ItemRarity.Magic,
-            EpicLootRarity.Rare => ItemRarity.Rare,
-            EpicLootRarity.Epic => ItemRarity.Epic,
-            EpicLootRarity.Legendary => ItemRarity.Legendary,
-        };
-
-    public static EpicLootRarity ToRarity(this ItemRarity rarity)
-        => rarity switch
-        {
-            ItemRarity.Magic => EpicLootRarity.Magic,
-            ItemRarity.Rare => EpicLootRarity.Rare,
-            ItemRarity.Epic => EpicLootRarity.Epic,
-            ItemRarity.Legendary => EpicLootRarity.Legendary,
-        };
 }

--- a/src/SpawnThat/Integrations/MobAi/Extensions/ILocalSpawnBuilderMobAiExtensions.cs
+++ b/src/SpawnThat/Integrations/MobAi/Extensions/ILocalSpawnBuilderMobAiExtensions.cs
@@ -9,9 +9,11 @@ public static class ILocalSpawnBuilderMobAiExtensions
     {
         if (IntegrationManager.InstalledMobAI)
         {
-            builder.SetModifier(new ModifierSetAI(aiName, mobAiConfig));
+            SetModifier(builder, aiName, mobAiConfig);
         }
 
         return builder;
     }
+
+    private static void SetModifier(ILocalSpawnBuilder builder, string aiName, string mobAiConfig) => builder.SetModifier(new ModifierSetAI(aiName, mobAiConfig));
 }

--- a/src/SpawnThat/Integrations/MobAi/Extensions/IWorldSpawnBuilderMobAiExtensions.cs
+++ b/src/SpawnThat/Integrations/MobAi/Extensions/IWorldSpawnBuilderMobAiExtensions.cs
@@ -9,9 +9,11 @@ public static class IWorldSpawnBuilderMobAiExtensions
     {
         if (IntegrationManager.InstalledMobAI)
         {
-            builder.SetModifier(new ModifierSetAI(aiName, mobAiConfig));
+            SetModifier(builder, aiName, mobAiConfig);
         }
 
         return builder;
     }
+
+    private static void SetModifier(IWorldSpawnBuilder builder, string aiName, string mobAiConfig) => builder.SetModifier(new ModifierSetAI(aiName, mobAiConfig));
 }

--- a/src/SpawnThat/SpawnThat.csproj
+++ b/src/SpawnThat/SpawnThat.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <AssemblyName>Valheim.SpawnThat</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/SpawnThat/SpawnThatPlugin.cs
+++ b/src/SpawnThat/SpawnThatPlugin.cs
@@ -13,7 +13,7 @@ namespace SpawnThat
     {
         public const string ModId = "asharppen.valheim.spawn_that";
         public const string PluginName = "Spawn That!";
-        public const string Version = "1.0.2";
+        public const string Version = "1.0.3";
 
         // Awake is called once when both the game and the plug-in are loaded
         void Awake()

--- a/src/SpawnThat/Spawners/LocalSpawner/Configuration/BepInEx/CreatureSpawnerConfigApplier.cs
+++ b/src/SpawnThat/Spawners/LocalSpawner/Configuration/BepInEx/CreatureSpawnerConfigApplier.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using SpawnThat.Core;
 using SpawnThat.Core.Configuration;
+using SpawnThat.Integrations;
 using SpawnThat.Options.Modifiers;
 using SpawnThat.Utilities;
 
@@ -70,34 +72,40 @@ internal static class CreatureSpawnerConfigApplier
         Config cfg;
 
         {
-            if (config.TryGet(CreatureSpawnerConfigCLLC.ModName, out cfg) &&
-                cfg is CreatureSpawnerConfigCLLC cllcConfig)
+            if (IntegrationManager.InstalledCLLC)
             {
-                if (cllcConfig.SetBossAffix.Value.IsNotEmpty())
+                if (config.TryGet(CreatureSpawnerConfigCLLC.ModName, out cfg) &&
+                    cfg is CreatureSpawnerConfigCLLC cllcConfig)
                 {
-                    builder.SetCllcModifierBossAffix(cllcConfig.SetBossAffix.Value);
-                }
-                if (cllcConfig.SetExtraEffect.Value.IsNotEmpty())
-                {
-                    builder.SetCllcModifierExtraEffect(cllcConfig.SetExtraEffect.Value);
-                }
-                if (cllcConfig.SetInfusion.Value.IsNotEmpty())
-                {
-                    builder.SetCllcModifierInfusion(cllcConfig.SetInfusion.Value);
-                }
+                    if (cllcConfig.SetBossAffix.Value.IsNotEmpty())
+                    {
+                        builder.SetCllcModifierBossAffix(cllcConfig.SetBossAffix.Value);
+                    }
+                    if (cllcConfig.SetExtraEffect.Value.IsNotEmpty())
+                    {
+                        builder.SetCllcModifierExtraEffect(cllcConfig.SetExtraEffect.Value);
+                    }
+                    if (cllcConfig.SetInfusion.Value.IsNotEmpty())
+                    {
+                        builder.SetCllcModifierInfusion(cllcConfig.SetInfusion.Value);
+                    }
 
-                if (cllcConfig.UseDefaultLevels.Value)
-                {
-                    builder.SetModifier(new ModifierDefaultRollLevel(config.LevelMin.Value, config.LevelMax.Value, 0, config.LevelUpChance.Value));
+                    if (cllcConfig.UseDefaultLevels.Value)
+                    {
+                        builder.SetModifier(new ModifierDefaultRollLevel(config.LevelMin.Value, config.LevelMax.Value, 0, config.LevelUpChance.Value));
+                    }
                 }
             }
 
-            if (config.TryGet(CreatureSpawnerConfigMobAI.ModName, out cfg) &&
-                cfg is CreatureSpawnerConfigMobAI mobAIConfig)
+            if (IntegrationManager.InstalledMobAI)
             {
-                if (mobAIConfig.SetAI.Value.IsNotEmpty())
+                if (config.TryGet(CreatureSpawnerConfigMobAI.ModName, out cfg) &&
+                    cfg is CreatureSpawnerConfigMobAI mobAIConfig)
                 {
-                    builder.SetMobAiModifier(mobAIConfig.SetAI.Value, mobAIConfig.AIConfigFile.Value);
+                    if (mobAIConfig.SetAI.Value.IsNotEmpty())
+                    {
+                        builder.SetMobAiModifier(mobAIConfig.SetAI.Value, mobAIConfig.AIConfigFile.Value);
+                    }
                 }
             }
         }

--- a/src/SpawnThat/Spawners/LocalSpawner/Configuration/LocalSpawnerConfiguration.cs
+++ b/src/SpawnThat/Spawners/LocalSpawner/Configuration/LocalSpawnerConfiguration.cs
@@ -77,6 +77,8 @@ internal class LocalSpawnerConfiguration : ISpawnerConfiguration
             return existing;
         }
 
+        Log.LogDebug($"Adding local spawner for spawner with name '{identifier.SpawnerPrefabName}'.");
+
         return spawnerBuilders[identifier] = new LocalSpawnBuilder();
     }
 
@@ -91,6 +93,8 @@ internal class LocalSpawnerConfiguration : ISpawnerConfiguration
             return existing;
         }
 
+        Log.LogDebug($"Adding local spawner for location '{identifier.Location}' with prefab '{identifier.PrefabName}'.");
+
         return locationBuilders[identifier] = new LocalSpawnBuilder();
     }
 
@@ -104,6 +108,8 @@ internal class LocalSpawnerConfiguration : ISpawnerConfiguration
 
             return existing;
         }
+
+        Log.LogDebug($"Adding local spawner for room '{identifier.Room}' with prefab '{identifier.PrefabName}'.");
 
         return roomBuilders[identifier] = new LocalSpawnBuilder();
     }

--- a/src/SpawnThat/Spawners/LocalSpawner/Models/LocationIdentifier.cs
+++ b/src/SpawnThat/Spawners/LocalSpawner/Models/LocationIdentifier.cs
@@ -23,7 +23,7 @@ internal record LocationIdentifier
         }
 #endif
 
-        Location = location.Trim();
-        PrefabName = prefabName.Trim();
+        Location = location.Trim().ToUpperInvariant();
+        PrefabName = prefabName.Trim().ToUpperInvariant();
     }
 }

--- a/src/SpawnThat/Spawners/LocalSpawner/Models/RoomIdentifier.cs
+++ b/src/SpawnThat/Spawners/LocalSpawner/Models/RoomIdentifier.cs
@@ -23,9 +23,7 @@ internal record RoomIdentifier
             Log.LogWarning("LocalSpawner builder with empty prefabName for RoomIdentifier detected.");
         }
 #endif
-
-
-        Room = room.Trim();
-        PrefabName = prefabName.Trim();
+        Room = room.Trim().ToUpperInvariant();
+        PrefabName = prefabName.Trim().ToUpperInvariant();
     }
 }

--- a/src/SpawnThat/Spawners/WorldSpawner/Configurations/BepInEx/SpawnSystemConfigApplier.cs
+++ b/src/SpawnThat/Spawners/WorldSpawner/Configurations/BepInEx/SpawnSystemConfigApplier.cs
@@ -6,6 +6,7 @@ using SpawnThat.Utilities;
 using SpawnThat.Options.Modifiers;
 using System.Collections.Generic;
 using SpawnThat.Integrations.CLLC.Models;
+using SpawnThat.Integrations;
 
 namespace SpawnThat.Spawners.WorldSpawner.Configurations.BepInEx;
 
@@ -115,25 +116,31 @@ internal static class SpawnSystemConfigApplier
         Config cfg;
 
         {
-            if (config.TryGet(SpawnSystemConfigCLLC.ModName, out cfg) &&
-                cfg is SpawnSystemConfigCLLC cllcConfig)
+            if (IntegrationManager.InstalledCLLC)
             {
-                if (cllcConfig.ConditionWorldLevelMin.Value >= 0 || cllcConfig.ConditionWorldLevelMax.Value >= 0)
+                if (config.TryGet(SpawnSystemConfigCLLC.ModName, out cfg) &&
+                    cfg is SpawnSystemConfigCLLC cllcConfig)
                 {
-                    builder.SetCllcConditionWorldLevel(cllcConfig.ConditionWorldLevelMin.Value, cllcConfig.ConditionWorldLevelMax.Value);
+                    if (cllcConfig.ConditionWorldLevelMin.Value >= 0 || cllcConfig.ConditionWorldLevelMax.Value >= 0)
+                    {
+                        builder.SetCllcConditionWorldLevel(cllcConfig.ConditionWorldLevelMin.Value, cllcConfig.ConditionWorldLevelMax.Value);
+                    }
                 }
             }
 
-            if (config.TryGet(SpawnSystemConfigEpicLoot.ModName, out cfg) &&
-                cfg is SpawnSystemConfigEpicLoot elConfig)
+            if (IntegrationManager.InstalledEpicLoot)
             {
-                if (elConfig.ConditionNearbyPlayerCarryLegendaryItem.Value.IsNotEmpty())
+                if (config.TryGet(SpawnSystemConfigEpicLoot.ModName, out cfg) &&
+                    cfg is SpawnSystemConfigEpicLoot elConfig)
                 {
-                    builder.SetEpicLootConditionNearbyPlayerCarryLegendaryItem((int)config.DistanceToTriggerPlayerConditions.Value, elConfig.ConditionNearbyPlayerCarryLegendaryItem.Value.SplitByComma());
-                }
-                if (elConfig.ConditionNearbyPlayerCarryItemWithRarity.Value.IsNotEmpty())
-                {
-                    builder.SetEpicLootConditionNearbyPlayersCarryItemWithRarity((int)config.DistanceToTriggerPlayerConditions.Value, elConfig.ConditionNearbyPlayerCarryItemWithRarity.Value.SplitByComma());
+                    if (elConfig.ConditionNearbyPlayerCarryLegendaryItem.Value.IsNotEmpty())
+                    {
+                        builder.SetEpicLootConditionNearbyPlayerCarryLegendaryItem((int)config.DistanceToTriggerPlayerConditions.Value, elConfig.ConditionNearbyPlayerCarryLegendaryItem.Value.SplitByComma());
+                    }
+                    if (elConfig.ConditionNearbyPlayerCarryItemWithRarity.Value.IsNotEmpty())
+                    {
+                        builder.SetEpicLootConditionNearbyPlayersCarryItemWithRarity((int)config.DistanceToTriggerPlayerConditions.Value, elConfig.ConditionNearbyPlayerCarryItemWithRarity.Value.SplitByComma());
+                    }
                 }
             }
         }
@@ -158,39 +165,45 @@ internal static class SpawnSystemConfigApplier
 
         // Modifiers - Integrations
         {
-            if (config.TryGet(SpawnSystemConfigCLLC.ModName, out cfg) &&
-                cfg is SpawnSystemConfigCLLC cllcConfig)
+            if (IntegrationManager.InstalledCLLC)
             {
-                if (cllcConfig.SetBossAffix.Value.IsNotEmpty() &&
-                    Enum.TryParse(cllcConfig.SetBossAffix.Value, out CllcBossAffix bossAffix))
+                if (config.TryGet(SpawnSystemConfigCLLC.ModName, out cfg) &&
+                    cfg is SpawnSystemConfigCLLC cllcConfig)
                 {
-                    builder.SetCllcModifierBossAffix(bossAffix);
-                }
+                    if (cllcConfig.SetBossAffix.Value.IsNotEmpty() &&
+                        Enum.TryParse(cllcConfig.SetBossAffix.Value, out CllcBossAffix bossAffix))
+                    {
+                        builder.SetCllcModifierBossAffix(bossAffix);
+                    }
 
-                if (cllcConfig.SetExtraEffect.Value.IsNotEmpty() &&
-                    Enum.TryParse(cllcConfig.SetExtraEffect.Value, out CllcCreatureExtraEffect extraEffect))
-                {
-                    builder.SetCllcModifierExtraEffect(extraEffect);
-                }
+                    if (cllcConfig.SetExtraEffect.Value.IsNotEmpty() &&
+                        Enum.TryParse(cllcConfig.SetExtraEffect.Value, out CllcCreatureExtraEffect extraEffect))
+                    {
+                        builder.SetCllcModifierExtraEffect(extraEffect);
+                    }
 
-                if (cllcConfig.SetInfusion.Value.IsNotEmpty() &&
-                    Enum.TryParse(cllcConfig.SetInfusion.Value, out CllcCreatureInfusion infusion))
-                {
-                    builder.SetCllcModifierInfusion(infusion);
-                }
+                    if (cllcConfig.SetInfusion.Value.IsNotEmpty() &&
+                        Enum.TryParse(cllcConfig.SetInfusion.Value, out CllcCreatureInfusion infusion))
+                    {
+                        builder.SetCllcModifierInfusion(infusion);
+                    }
 
-                if (cllcConfig.UseDefaultLevels.Value)
-                {
-                    builder.SetModifier(new ModifierDefaultRollLevel(config.LevelMin.Value, config.LevelMax.Value, 0, 10f));
+                    if (cllcConfig.UseDefaultLevels.Value)
+                    {
+                        builder.SetModifier(new ModifierDefaultRollLevel(config.LevelMin.Value, config.LevelMax.Value, 0, 10f));
+                    }
                 }
             }
 
-            if (config.TryGet(SpawnSystemConfigMobAI.ModName, out cfg) &&
-                cfg is SpawnSystemConfigMobAI mobAIConfig)
+            if (IntegrationManager.InstalledMobAI)
             {
-                if (mobAIConfig.SetAI.Value.IsNotEmpty())
+                if (config.TryGet(SpawnSystemConfigMobAI.ModName, out cfg) &&
+                    cfg is SpawnSystemConfigMobAI mobAIConfig)
                 {
-                    builder.SetMobAiModifier(mobAIConfig.SetAI.Value, mobAIConfig.AIConfigFile.Value);
+                    if (mobAIConfig.SetAI.Value.IsNotEmpty())
+                    {
+                        builder.SetMobAiModifier(mobAIConfig.SetAI.Value, mobAIConfig.AIConfigFile.Value);
+                    }
                 }
             }
         }

--- a/src/SpawnThat/Utilities/Extensions/CodeInstructionExtensions.cs
+++ b/src/SpawnThat/Utilities/Extensions/CodeInstructionExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace SpawnThat.Utilities.Extensions;
+
+internal static class CodeInstructionExtensions
+{
+    /// <summary>
+    /// Returns corresponding ldloc for stloc instructions.
+    /// If instruction is not an stloc, it returns itself.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static CodeInstruction GetLdlocFromStLoc(this CodeInstruction instruction)
+    {
+        if (instruction.opcode == OpCodes.Stloc_0)
+        {
+            return new(OpCodes.Ldloc_0);
+        }
+        if (instruction.opcode == OpCodes.Stloc_1)
+        {
+            return new(OpCodes.Ldloc_1);
+        }
+        if (instruction.opcode == OpCodes.Stloc_2)
+        {
+            return new(OpCodes.Ldloc_2);
+        }
+        if (instruction.opcode == OpCodes.Stloc_3)
+        {
+            return new(OpCodes.Ldloc_3);
+        }
+        if (instruction.opcode == OpCodes.Stloc_S)
+        {
+            return new(OpCodes.Ldloca_S, instruction.operand);
+        }
+        if (instruction.opcode == OpCodes.Stloc)
+        {
+            return new(OpCodes.Ldloc, instruction.operand);
+        }
+
+        throw new ArgumentException($"Unexpected instruction '{instruction}' encountered. Expected an {OpCodes.Stloc}.");
+    }
+
+    /// <summary>
+    /// Returns corresponding stloc for ldloc instructions.
+    /// If instruction is not an ldloc, it returns itself.
+    /// </summary>
+    public static CodeInstruction GetStlocFromLdloc(this CodeInstruction instruction)
+    {
+        if (instruction.opcode == OpCodes.Ldloc_0)
+        {
+            return new(OpCodes.Stloc_0);
+        }
+        if (instruction.opcode == OpCodes.Ldloc_1)
+        {
+            return new(OpCodes.Stloc_1);
+        }
+        if (instruction.opcode == OpCodes.Ldloc_2)
+        {
+            return new(OpCodes.Stloc_2);
+        }
+        if (instruction.opcode == OpCodes.Ldloc_3)
+        {
+            return new(OpCodes.Stloc_3);
+        }
+        if (instruction.opcode == OpCodes.Ldloca_S)
+        {
+            return new(OpCodes.Stloc_S, instruction.operand);
+        }
+        if (instruction.opcode == OpCodes.Ldloc)
+        {
+            return new(OpCodes.Stloc, instruction.operand);
+        }
+
+        throw new ArgumentException($"Unexpected instruction '{instruction}' encountered. Expected an {OpCodes.Ldloc}.");
+    }
+}


### PR DESCRIPTION
- Fixed local spawner file-configs not being properly matched with spawners.
- Fixed error when printing world spawners with missing prefab to debug file.
- Fixed error when having file-configurations with integrations not installed.
- Added robustness to API when setting up configurations for uninstalled integrations.
- Added robustness for v0.207.15. Closes #131 